### PR TITLE
Update the Docker to work correctly

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:latest
+FROM alpine:3.12
 
 RUN apk update && apk upgrade
 RUN apk add iptables python3 py3-requests wireguard-tools wireguard-virt openssh-client

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,5 +29,5 @@ services:
       #
       # Manditory variables
       #
-      - APITOKEN=${APITOKEN?}
-      - FACTORY=${FACTORY?}
+      - APITOKEN=${APITOKEN}
+      - FACTORY=${FACTORY}


### PR DESCRIPTION
The alpine:latest is not fully populated so backing it down
to 3.12.

As for the docker-compose.yml not all versions of docker/docker-compose
will work with the manditory format so remove that.

Signed-off-by: Tim Anderson <tim.anderson@foundries.io>