### PR TITLE
Fix unbound local error

### DIFF
--- a/factory-wireguard.py
+++ b/factory-wireguard.py
@@ -148,7 +148,7 @@ class FactoryDevice:
                 if cfg:
                     yield cls(d["name"], cfg[0], cfg[1])
 
-            next_url = d.get("next")
+            next_url = data.get("next")
             if not next_url:
                 break
             data = api.get(next_url)


### PR DESCRIPTION
This happens on a factory with no devices. It also prevents pagination
from working for a factory with many devices.

Signed-off-by: Andy Doan <andy@foundries.io>