### PR TITLE
README: fix example with --no-check-ip

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,8 +60,8 @@ Then you can do this configure step:
    --apitoken <api token> \  # https://app.foundries.io/settings/tokens
    --factory <factory> \
    --privatekey /root/wgpriv.key \ # where to store generated private key
-   --no-check-ip \
-   enable
+   enable \
+   --no-check-ip
 ~~~
 
 Which will allow the endpoint to be used without a verification check.


### PR DESCRIPTION
--no-check-ip is an argument for 'enable' subparser so it has to be
added after 'enable'. This patch fixes the example in README file.

Signed-off-by: Milosz Wasilewski <milosz.wasilewski@foundries.io>