### PR TITLE
Limit interface name length

### DIFF
--- a/factory-wireguard.py
+++ b/factory-wireguard.py
@@ -501,6 +501,10 @@ def _get_args():
         )
     elif not args.intf_name:
         args.intf_name = "fio" + args.factory
+    if len(args.intf_name) > 15:
+        sys.exit(
+            "ERROR: --intf-name argument is too long. Max length is 15 characters."
+        )
     return args
 
 


### PR DESCRIPTION
Interface name can be 15 characters long at maximum. Wireguard fails to
start for longer interface names. This patch adds a check to command
line option. If the interface name is too long only error message is
printed and the program exits.

Signed-off-by: Milosz Wasilewski <milosz.wasilewski@foundries.io>