### PR TITLE
Add oauth2 support

### DIFF
--- a/factory-wireguard.py
+++ b/factory-wireguard.py
@@ -78,7 +78,11 @@ class FactoryApi:
         try:
             with open(credsfile) as f:
                 data = json.load(f)
-            raise NotImplementedError
+
+            now = time.time()
+            if now > data["created"] + data["expires_in"] - 600:  # 600 for some slack
+                raise NotImplemented()
+            return {"Authorization": "Bearer " + data["access_token"]}
         except FileNotFoundError:
             return self._register_oauth(factory, credsfile)
 

--- a/factory-wireguard.py
+++ b/factory-wireguard.py
@@ -336,6 +336,11 @@ def _assert_ip(ip: str):
 
 
 def configure_factory(args):
+    if os.path.exists(args.oauthcreds):
+        sys.exit(
+            "ERROR: Credentials file %s already exists. You must remove this file to continue"
+            % args.oauthcreds
+        )
     if not args.endpoint:
         args.endpoint = WgServer.probe_external_ip()
 


### PR DESCRIPTION
We currently have an awkward process of creating two API tokens in the webui and using them to get this service running. This change introduces an oauth2 flow that does things in a more streamlined user-friendly manner. It should help simplify our docs.fio information for this.