### PR TITLE
Only check for oauth file if selected oauth authentication

### DIFF
--- a/factory-wireguard.py
+++ b/factory-wireguard.py
@@ -336,11 +336,12 @@ def _assert_ip(ip: str):
 
 
 def configure_factory(args):
-    if os.path.exists(args.oauthcreds):
-        sys.exit(
-            "ERROR: Credentials file %s already exists. You must remove this file to continue"
-            % args.oauthcreds
-        )
+    if not args.apitoken:
+        if os.path.exists(args.oauthcreds):
+            sys.exit(
+                "ERROR: Credentials file %s already exists. You must remove this file to continue"
+                % args.oauthcreds
+            )
     if not args.endpoint:
         args.endpoint = WgServer.probe_external_ip()
 


### PR DESCRIPTION
This was checking for the existance of a file that was set to
None if using apitoken for authentication.

Signed-off-by: Tim Anderson <tim.anderson@foundries.io>